### PR TITLE
Added in support for HEAD HTTP header in rest client driver as per Issue #20

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverRequest.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverRequest.java
@@ -28,7 +28,7 @@ public final class ClientDriverRequest {
      * HTTP method enum for specifying which method you expect to be called with.
      */
     public enum Method {
-        GET, POST, PUT, DELETE, OPTIONS
+        GET, POST, PUT, DELETE, OPTIONS, HEAD
     }
 
     private final Object path;

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
@@ -25,11 +25,13 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,8 +39,7 @@ import org.junit.rules.ExpectedException;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class ClientDriverSuccessTest {
 
@@ -294,4 +295,34 @@ public class ClientDriverSuccessTest {
         client.execute(get);
     }
 
+    @Test
+    public void testHttpHEADMatchesHttpGETExceptForEntity() throws Exception {
+
+        final String baseUrl = driver.getBaseUrl();
+	final String URL = baseUrl + "/blah2";
+	
+        driver.addExpectation(
+                new ClientDriverRequest("/blah2").withMethod(Method.GET),
+                new ClientDriverResponse("something").withStatus(200).withHeader("Allow", "GET, HEAD"));
+        driver.addExpectation(
+                new ClientDriverRequest("/blah2").withMethod(Method.HEAD),
+                new ClientDriverResponse("something").withStatus(200).withHeader("Allow", "GET, HEAD"));
+
+        final HttpClient client = new DefaultHttpClient();
+        
+        final HttpHead headRequest = new HttpHead(URL);
+        final HttpResponse headResponse = client.execute(headRequest);
+        
+        final HttpGet getRequest = new HttpGet(URL);
+        final HttpResponse getResponse = client.execute(getRequest);
+        
+        assertThat(headResponse.getStatusLine().getStatusCode(), is(200));
+        assertThat(headResponse.getHeaders("Allow")[0].getValue(), equalTo("GET, HEAD"));
+        assertThat(headResponse.getAllHeaders().length, is(getResponse.getAllHeaders().length));
+
+        final String getEntityBody = EntityUtils.toString(getResponse.getEntity());        
+        assertThat(getEntityBody, is("something"));
+        
+        assertThat(headResponse.getEntity(), nullValue());
+    }    
 }


### PR DESCRIPTION
Just checking that I've got the hang of the whole fork+pull request workflow really. The change itself is pretty minimal - just a new unit test to confirm that HTTP HEAD returns an identical response to HTTP GET except minus the entity. Could probably do with something more sophisticated for asserting that the response from the GET is "almost identical" to the response from HEAD response.

Not sure if this covers all the scope of issue #20 or not.
