### PR TITLE
Added support HTTP TRACE

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverRequest.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverRequest.java
@@ -35,7 +35,7 @@ public final class ClientDriverRequest {
      * HTTP method enum for specifying which method you expect to be called with.
      */
     public enum Method {
-        GET, POST, PUT, DELETE, OPTIONS, HEAD
+        GET, POST, PUT, DELETE, OPTIONS, HEAD, TRACE
     }
 
     private final Object path;

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
@@ -19,16 +19,19 @@ import static com.github.restdriver.clientdriver.RestClientDriver.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
+import java.io.IOException;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpTrace;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicHeader;
@@ -343,4 +346,18 @@ public class ClientDriverSuccessTest {
         assertThat(getEntityBody, is("something"));
     }
     
+    @Test
+    public void testHttpTRACE() throws ClientProtocolException, IOException {
+    	
+        String baseUrl = driver.getBaseUrl();
+        driver.addExpectation(
+                onRequestTo("/blah2").withMethod(Method.TRACE),
+                giveResponse(null).withStatus(200));
+
+        HttpClient client = new DefaultHttpClient();
+        HttpTrace trace = new HttpTrace(baseUrl + "/blah2");
+        HttpResponse response = client.execute(trace);
+
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+    }
 }


### PR DESCRIPTION
Does what it says on the tin... It's a very simple change.

Note that a user can still set an expectation of a specific Content-Type and entity body on the response despite the fact that for a successful TRACE response the Content-Type MUST be "message/http" and the entity MUST be the HTTP message from the request. (See http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.8).

I'm assuming that this flexibility is ok as perhaps the user actually _wants_ to have unexpected behaviour for the TRACE response.
