### PR TITLE
Add a match handler

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverExpectation.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverExpectation.java
@@ -26,6 +26,7 @@ public class ClientDriverExpectation {
     private int numberOfTimes = 1;
     private int numberOfMatches;
     private boolean matchAnyTimes;
+    private MatchedRequestHandler matchedRequestHandler = new NullRequestHandler();
     
     /**
      * Creates a new expectation instance.
@@ -47,28 +48,34 @@ public class ClientDriverExpectation {
     
     /**
      * Indicate that this expectation should be matched a given number of times.
-     * 
+     *
      * @param times The number of times this expectation should be matched
      */
-    public final void times(int times) {
+    public final ClientDriverExpectation times(int times) {
         if (times < 1) {
             throw new ClientDriverInvalidExpectationException("Expectation cannot be matched less than once");
         }
         numberOfTimes = times;
+
+        return this;
     }
     
     /**
      * Indicate that this expectation should be matched any number of times.
      */
-    public final void anyTimes() {
+    public final ClientDriverExpectation anyTimes() {
         matchAnyTimes = true;
+        return this;
     }
     
     /**
      * Indicate that this expectation has been matched.
+     * @param realRequest
      */
-    public final void match() {
+    public final void match(HttpRealRequest realRequest) {
         numberOfMatches += 1;
+
+        matchedRequestHandler.onMatch(realRequest);
     }
     
     /**
@@ -107,5 +114,15 @@ public class ClientDriverExpectation {
         return "expected: " + expectedString + ", actual: " + numberOfMatches;
         
     }
-    
+
+    /**
+     * When a call is matched call a handler
+     *
+     * @param matchedRequestHandler called when the request is matched
+     * @return
+     */
+    public ClientDriverExpectation whenMatched(MatchedRequestHandler matchedRequestHandler) {
+        this.matchedRequestHandler = matchedRequestHandler;
+        return this;
+    }
 }

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/MatchedRequestHandler.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/MatchedRequestHandler.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright © 2010-2011 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.restdriver.clientdriver;
+
+public interface MatchedRequestHandler {
+    void onMatch(HttpRealRequest matchedRequest);
+}

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/NullRequestHandler.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/NullRequestHandler.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright © 2010-2011 Nokia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.restdriver.clientdriver;
+
+public class NullRequestHandler implements MatchedRequestHandler {
+    @Override
+    public void onMatch(HttpRealRequest matchedRequest) {
+
+    }
+}

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/jetty/DefaultClientDriverJettyHandler.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/jetty/DefaultClientDriverJettyHandler.java
@@ -108,21 +108,22 @@ public final class DefaultClientDriverJettyHandler extends AbstractHandler imple
     }
     
     private ClientDriverRequestResponsePair getMatchingRequestPair(HttpServletRequest request) {
-        
-        int index = 0;
-        
+
         ClientDriverExpectation matchedExpectation = null;
         HttpRealRequest realRequest = new HttpRealRequest(request);
-        
+
+        int index;
         for (index = 0; index < expectations.size(); index++) {
             ClientDriverExpectation thisExpectation = expectations.get(index);
             ClientDriverRequestResponsePair thisPair = thisExpectation.getPair();
             if (matcher.isMatch(realRequest, thisPair.getRequest())) {
-                thisExpectation.match();
+
+                thisExpectation.match(realRequest);
                 if (matchedExpectation == null) {
                     matchedExpectation = thisExpectation;
                     break;
                 }
+
             }
         }
         

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverRuleTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverRuleTest.java
@@ -16,10 +16,17 @@
 package com.github.restdriver.clientdriver.integration;
 
 import static com.github.restdriver.clientdriver.RestClientDriver.*;
+import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
+import com.github.restdriver.clientdriver.ClientDriverRequest;
+import com.github.restdriver.clientdriver.HttpRealRequest;
+import com.github.restdriver.clientdriver.MatchedRequestHandler;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,41 +36,68 @@ import com.github.restdriver.clientdriver.ClientDriverRule;
 import com.github.restdriver.clientdriver.exception.ClientDriverFailedExpectationException;
 
 public class ClientDriverRuleTest {
-    
+
     @Rule
     public ClientDriverRule driver = new ClientDriverRule();
-    
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-    
+
     @Test
     public void letsTrySomethingThatFails() throws Exception {
-        
+
         // We use ExpectedException to catch the exception we (hopefully) get because the expectations weren't met
         thrown.expect(ClientDriverFailedExpectationException.class);
-        
+
         driver.addExpectation(onRequestTo("/blah"), giveResponse("OUCH!!").withStatus(200));
         driver.addExpectation(onRequestTo("/blah"), giveResponse("OUCH!!").withStatus(404));
-        
+
         HttpClient client = new DefaultHttpClient();
-        
+
         HttpPost post = new HttpPost(driver.getBaseUrl() + "/blah?gang=groon");
-        
+
         client.execute(post);
-        
+
     }
-    
+
     @Test
     public void letsTrySomethingThatWorks() throws Exception {
-        
+
         driver.addExpectation(onRequestTo("/blah"), giveResponse("").withStatus(404));
-        
+
         HttpClient client = new DefaultHttpClient();
-        
+
         HttpGet get = new HttpGet(driver.getBaseUrl() + "/blah");
-        
+
         client.execute(get);
-        
+
     }
-    
+
+    @Test
+    public void letsTrySomethingThatShouldCallbackOnMatch() throws Exception {
+
+        final boolean[] matched = new boolean[1];
+
+        driver.addExpectation(
+                onRequestTo("/path").withMethod(ClientDriverRequest.Method.POST),
+                giveResponse(""))
+                .anyTimes()
+                .whenMatched(new MatchedRequestHandler() {
+
+                    @Override
+                    public void onMatch(HttpRealRequest matchedRequest) {
+                        assertThat(matchedRequest.getBodyContent(), is("body"));
+                        matched[0] = true;
+                    }
+
+                });
+
+        HttpClient client = new DefaultHttpClient();
+        HttpPost post = new HttpPost(driver.getBaseUrl() + "/path");
+        post.setEntity(new StringEntity("body"));
+        client.execute(post);
+
+        assertTrue(matched[0]);
+    }
+
 }

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/unit/ClientDriverExpectationTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/unit/ClientDriverExpectationTest.java
@@ -17,7 +17,11 @@ package com.github.restdriver.clientdriver.unit;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
 
+import com.github.restdriver.clientdriver.HttpRealRequest;
+import com.github.restdriver.clientdriver.MatchedRequestHandler;
+import org.eclipse.jetty.server.Request;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -27,6 +31,8 @@ import com.github.restdriver.clientdriver.ClientDriverRequest;
 import com.github.restdriver.clientdriver.ClientDriverRequestResponsePair;
 import com.github.restdriver.clientdriver.ClientDriverResponse;
 import com.github.restdriver.clientdriver.exception.ClientDriverInvalidExpectationException;
+
+import javax.servlet.http.HttpServletRequest;
 
 public class ClientDriverExpectationTest {
     
@@ -71,12 +77,28 @@ public class ClientDriverExpectationTest {
         expectation.times(3);
         
         assertThat(expectation.isSatisfied(), is(false));
-        expectation.match();
+
+        HttpRealRequest realRequest = mock(HttpRealRequest.class);
+        
+        expectation.match(realRequest);
         assertThat(expectation.isSatisfied(), is(false));
-        expectation.match();
+        expectation.match(realRequest);
         assertThat(expectation.isSatisfied(), is(false));
-        expectation.match();
+        expectation.match(realRequest);
         assertThat(expectation.isSatisfied(), is(true));
+    }
+    
+    @Test
+    public void matchingExpectationCallsMatcher() {
+        MatchedRequestHandler matchHandlerMock = mock(MatchedRequestHandler.class);
+        ClientDriverExpectation expectation = new ClientDriverExpectation(PAIR);
+        expectation.whenMatched(matchHandlerMock);
+
+
+        HttpRealRequest realRequest = mock(HttpRealRequest.class);
+
+        expectation.match(realRequest);
+        verify(matchHandlerMock).onMatch(realRequest);
     }
     
     @Test


### PR DESCRIPTION
Add a way to add a match handler. It's useful for debugging to be
able to do something when a request is matched. For example, if
a logging URL is called it'd be nice to be able print the body
of the request.
