### PR TITLE
Fix parsing of request Content Types that include a charset

### DIFF
--- a/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/http/RequestBody.java
+++ b/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/http/RequestBody.java
@@ -15,6 +15,11 @@
  */
 package com.github.restdriver.serverdriver.http;
 
+import static org.apache.commons.lang.StringUtils.*;
+
+import javax.activation.MimeType;
+import javax.activation.MimeTypeParseException;
+
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ContentType;
@@ -24,60 +29,80 @@ import org.apache.http.entity.StringEntity;
  * Encapsulates a Request body for a method.
  */
 public final class RequestBody implements AnyRequestModifier {
-    
+
     private static final String DEFAULT_CONTENT_ENCODING = "UTF-8";
-    
+
     private final String content;
     private final String contentType;
-    
+
     /**
      * Creates a new request body instance.
      * 
-     * @param content A string to use for the content
-     * @param contentType A string representing the content-type
+     * @param content
+     *            A string to use for the content
+     * @param contentType
+     *            A string representing the content-type
      */
     public RequestBody(String content, String contentType) {
         this.content = content;
         this.contentType = contentType;
     }
-    
+
     /**
      * Gets the content of this request body.
      * 
      * @return The content as a string
      * 
-     * @deprecated This shouldn't need to be exposed. Expect it to go away in the future.
+     * @deprecated This shouldn't need to be exposed. Expect it to go away in
+     *             the future.
      */
     @Deprecated
     public String getContent() {
         return content;
     }
-    
+
     /**
      * Gets the content-type of this request body.
      * 
      * @return The content-type as a string
      * 
-     * @deprecated This shouldn't need to be exposed. Expect it to go away in the future.
+     * @deprecated This shouldn't need to be exposed. Expect it to go away in
+     *             the future.
      */
     @Deprecated
     public String getContentType() {
         return contentType;
     }
-    
+
     @Override
     public void applyTo(ServerDriverHttpUriRequest request) {
-        
+
         HttpUriRequest internalRequest = request.getHttpUriRequest();
-        
+
         if (!(internalRequest instanceof HttpEntityEnclosingRequest)) {
             return;
         }
-        
+
         HttpEntityEnclosingRequest entityRequest = (HttpEntityEnclosingRequest) internalRequest;
-        
+
         entityRequest.setHeader("Content-type", contentType);
-        entityRequest.setEntity(new StringEntity(content, ContentType.create(contentType, DEFAULT_CONTENT_ENCODING)));
-        
+        entityRequest.setEntity(new StringEntity(content, createContentType(contentType)));
+
     }
+
+    private ContentType createContentType(String contentType) {
+        try {
+
+            MimeType mimeType = new MimeType(contentType);
+
+            String mediaType = mimeType.getBaseType();
+            String charset = defaultString(mimeType.getParameter("charset"), DEFAULT_CONTENT_ENCODING);
+
+            return ContentType.create(mediaType, charset);
+
+        } catch (MimeTypeParseException e) {
+            throw new IllegalArgumentException("Invalid content type: " + contentType, e);
+        }
+    }
+
 }

--- a/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/http/RequestBodyTest.java
+++ b/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/http/RequestBodyTest.java
@@ -25,22 +25,39 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.Test;
 
 public class RequestBodyTest {
-    
+
     @Test
     public void bodyAppliesItselfToRequest() throws Exception {
         HttpPost request = new HttpPost();
-        RequestBody body = new RequestBody("content", "contentType");
+        RequestBody body = new RequestBody("content", "content/type");
         body.applyTo(new ServerDriverHttpUriRequest(request));
         assertThat(IOUtils.toString(request.getEntity().getContent()), is("content"));
-        assertThat(request.getEntity().getContentType().getValue(), is("contenttype; charset=UTF-8"));
-        assertThat(request.getFirstHeader("Content-type").getValue(), is("contentType"));
+        assertThat(request.getEntity().getContentType().getValue(), is("content/type; charset=UTF-8"));
+        assertThat(request.getFirstHeader("Content-type").getValue(), is("content/type"));
     }
-    
+
+    @Test
+    public void bodyAppliesItselfToRequestWhenContentTypeIncludesCharset() throws Exception {
+        HttpPost request = new HttpPost();
+        RequestBody body = new RequestBody("content", "text/plain;charset=UTF-8");
+        body.applyTo(new ServerDriverHttpUriRequest(request));
+        assertThat(IOUtils.toString(request.getEntity().getContent()), is("content"));
+        assertThat(request.getEntity().getContentType().getValue(), is("text/plain; charset=UTF-8"));
+        assertThat(request.getFirstHeader("Content-type").getValue(), is("text/plain;charset=UTF-8"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void applyToThrowsExceptionWhenContentTypeIsInvalid() throws Exception {
+        HttpPost request = new HttpPost();
+        RequestBody body = new RequestBody("content", "invalid;;;;");
+        body.applyTo(new ServerDriverHttpUriRequest(request));
+    }
+
     @Test
     public void applyToHandlesRequestWhichCannotHaveBody() {
         HttpUriRequest request = new HttpGet();
         RequestBody body = new RequestBody("content", "contentType");
         body.applyTo(new ServerDriverHttpUriRequest(request));
     }
-    
+
 }


### PR DESCRIPTION
In rest-server-driver 1.1.24 it's no longer possible to set a request content type that includes a charset, like:

``` java
put(url, body(bodyText, "text/plain; charset=utf-8"))
```

The above code produces an IllegalArgumentException with the message "MIME type may not contain reserved characters".

This patch fixes the problem by parsing the supplied content type before supplying both the base type and a charset to `org.apache.http.entity.ContentType#create`.

One (nice) side-effect of this patch is that content types must now be valid - it's no longer possible to use a content type like:

`mytype`

Since this isn't valid (it has no subtype) it causes an IllegalArgumentException.
