### PR TITLE
Move introduction and getting started docs from wiki to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,47 @@
 
 [![Build Status](https://secure.travis-ci.org/rest-driver/rest-driver.png?branch=master)](http://travis-ci.org/rest-driver/rest-driver)
 
-REST-driver is a pair of libraries for the external testing of your RESTful services and clients.  All details and useful information are kept on [the REST-driver wiki](https://github.com/rest-driver/rest-driver/wiki).
+Test Driver to test your RESTful services and clients
+
+There are two libraries here:
+
+* REST server driver - for testing your RESTful service
+* REST client driver - for testing your RESTful client & mocking remote services
+
+**Latest version: 1.1.27**
+
+[Downloads](https://github.com/rest-driver/rest-driver/wiki/Downloads) - [Server Driver](https://github.com/rest-driver/rest-driver/wiki/Server-Driver) - [Client Driver](https://github.com/rest-driver/rest-driver/wiki/Client-driver)
+
+##Goals
+
+Everyone knows that testing is good for your health and REST is good for your sanity.  Now it is easy to keep both in check by allowing you to write _quick_, _readable_, _fluid_ tests which are easy to refactor and give excellent error handling/reporting.  So we provide these libraries to test from both ends of the pipe.
+
+##REST server driver
+
+In order to do thorough testing of your RESTful service, you'll have to make actual HTTP requests and check the actual HTTP responses from your service.  REST driver makes this as easy as:
+
+```java
+Response response = get( "http://www.example.com" );
+
+assertThat(response, hasStatusCode(200));
+assertThat(response.asJson(), hasJsonPath("$.name", equalTo("jeff")));
+```
+
+More info: [Server Driver](https://github.com/rest-driver/rest-driver/wiki/Server-Driver)
+
+##REST client driver
+
+If you have a client for a RESTful service, it's not ideal to have an actual service running somewhere to test against.  This is difficult to keep on top of, makes for brittle/flickering tests, and tightly couples your tests to someone else's code.
+
+We provide a mock-like interface which launches a real HTTP server and allows setup like this:
+
+```java
+clientDriver.addExpectation(onRequestTo("/").withMethod(Method.GET), 
+                            giveResponse("some wonderful content").withHeader("Content-Type", "text/plain"));
+```
+
+The server will listen for a requests and respond with the replies you set.  Any unexpected action or unmet expectation will fail your tests.
+
+You can also use the client-driver to mock out any remote services which your RESTful service uses.
+
+More info: [Client Driver](https://github.com/rest-driver/rest-driver/wiki/Client-driver)

--- a/src/main/scripts/reversion.sh
+++ b/src/main/scripts/reversion.sh
@@ -19,6 +19,11 @@ for MODULE in "rest-driver" "rest-client-driver" "rest-server-driver"; do
   done
 done
 
+perl -pi -e "s/\d+\.\d+\.\d+/$VERSION/g" README.md
+git add README.md
+git commit -m "Updating README.md to $VERSION"
+git push
+
 mkdir -p $WORKING_DIRECTORY
 cd $WORKING_DIRECTORY
 git clone git@github.com:rest-driver/rest-driver.wiki.git $WORKING_DIRECTORY/rest-driver.wiki


### PR DESCRIPTION
The current rest-driver homepage is a little unfriendly. All the introduction and useful information is tucked away in the wiki.

This patch moves the contents of `Home.md` from the wiki to `README.md` in the project repo. I've also updated the reversion script to include `README.md` in its reversioning.

When this patch is merged, we can remove/update `Home.md`.
