### PR TITLE
Remove Content-Type for empty responses

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverResponse.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverResponse.java
@@ -18,6 +18,7 @@ package com.github.restdriver.clientdriver;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import static org.apache.commons.lang.StringUtils.*;
 
 /**
  * Class for encapsulating an HTTP response.
@@ -56,8 +57,11 @@ public final class ClientDriverResponse {
     public ClientDriverResponse(String content) {
         this.content = content;
         this.status = statusCodeForContent(content);
-        this.contentType = DEFAULT_CONTENT_TYPE;
         headers = new HashMap<String, String>();
+        
+        if (isNotEmpty(content)) {
+            this.contentType = DEFAULT_CONTENT_TYPE;
+        }
     }
     
     private static int statusCodeForContent(String content) {

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
@@ -424,6 +424,21 @@ public class ClientDriverSuccessTest {
     }
     
     @Test
+    public void emptyResponseHasNoContentType() throws Exception {
+        
+        driver.addExpectation(
+                onRequestTo("/foo"),
+                giveEmptyResponse().withStatus(200));
+        
+        HttpClient client = new DefaultHttpClient();
+        HttpMethodWithBody get = new HttpMethodWithBody("GET", driver.getBaseUrl() + "/foo");
+        HttpResponse response = client.execute(get);
+        
+        assertThat(response.getHeaders("Content-Type").length, is(0));
+        
+    }
+    
+    @Test
     public void bodyIsAllowedForDelete() throws Exception {
         
         driver.addExpectation(

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/unit/ClientDriverResponseTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/unit/ClientDriverResponseTest.java
@@ -44,7 +44,16 @@ public class ClientDriverResponseTest {
         
         assertThat(response.getStatus(), is(200));
     }
-    
+
+    @Test
+    public void creatingEmptyResponseGivesNoContentType() {
+        
+        assertThat(new ClientDriverResponse().getContentType(), is(nullValue()));
+        assertThat(new ClientDriverResponse(null).getContentType(), is(nullValue()));
+        assertThat(new ClientDriverResponse("").getContentType(), is(nullValue()));
+        
+    }
+
     @Test
     public void usingHeaderCanOverrideContentType() {
         ClientDriverResponse response = new ClientDriverResponse("hello").withContentType("text/plain");

--- a/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/ResponseToStringAcceptanceTest.java
+++ b/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/ResponseToStringAcceptanceTest.java
@@ -54,7 +54,6 @@ public class ResponseToStringAcceptanceTest {
         Response response = get(baseUrl);
         
         assertThat(response.toString(), containsString("HTTP/1.1 400 Bad Request"));
-        assertThat(response.toString(), containsString("Content-Type: text/plain;charset=ISO-8859-1"));
         assertThat(response.toString(), containsString("Content-Length: 0"));
         assertThat(response.toString(), containsString("Server: rest-client-driver("));
         


### PR DESCRIPTION
The default content type is now only set when the body is not empty.
