### PR TITLE
Upgrade to JUnit 4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <jackson.version>2.0.2</jackson.version>
         <jetty.version>8.1.0.v20120127</jetty.version>
         <joda.time.version>2.1</joda.time.version>
-        <junit.version>4.10</junit.version>
+        <junit.version>4.11</junit.version>
         <jsonpath.version>0.8.1</jsonpath.version>
         <mockito.version>1.9.0</mockito.version>
         <servlet.api.version>2.5</servlet.api.version>

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/FailureReportingTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/FailureReportingTest.java
@@ -59,6 +59,7 @@ public class FailureReportingTest {
     @Test
     public void assertionFailureIsReportedCorrectly() throws Exception {
         
+        thrown.handleAssertionErrors();
         thrown.expect(AssertionError.class);
         
         clientDriver.addExpectation(onRequestTo("/one"), giveEmptyResponse());


### PR DESCRIPTION
Fix a conflict with Hamcrest matcher classes that was previously fixed
by classpath ordering. This brings JUnit's Hamcrest dependency up to
version 1.3, which is _more_ compatible with rest-driver's other
dependencies.

This should make using rest-driver (in particular the HasXPath matcher)
easier in Clojure.
