### PR TITLE
Problem running "mvn test" with locale sv_SE.UTF-8 (guess).

### DIFF
--- a/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/matchers/Rfc1123DateMatcher.java
+++ b/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/matchers/Rfc1123DateMatcher.java
@@ -17,6 +17,7 @@ package com.github.restdriver.serverdriver.matchers;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -41,7 +42,7 @@ public final class Rfc1123DateMatcher extends TypeSafeMatcher<Header> {
      * @return The DateTime object set to UTC.
      */
     public DateTime getDateTime(String rawString) {
-        SimpleDateFormat formatter = new SimpleDateFormat(DATE_FORMAT);
+        SimpleDateFormat formatter = new SimpleDateFormat(DATE_FORMAT, Locale.US);
         formatter.setLenient(false); // This stops well-formatted but invalid dates like Feb 31
         
         try {


### PR DESCRIPTION
I had issues simply doing a "mvn test". It seems setting the SimpleDateFormat's locale to US helped it. Maybe there's defaults in SDF getting set from me building on a Swedish box.

(I needed to get this fixed in order to provide the next pull request)
