### PR TITLE
Capture body after remove from expectations list

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/DefaultRequestMatcher.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/DefaultRequestMatcher.java
@@ -61,15 +61,7 @@ public final class DefaultRequestMatcher implements RequestMatcher {
             return false;
         }
 
-        captureBodyIfRequired(realRequest, expectedRequest);
-
         return true;
-    }
-
-    private void captureBodyIfRequired(RealRequest realRequest, ClientDriverRequest expectedRequest) {
-        if (expectedRequest.getBodyCapture() != null) {
-            expectedRequest.getBodyCapture().setBody(realRequest.getBodyContent());
-        }
     }
 
     private boolean isSameMethod(RealRequest realRequest, ClientDriverRequest expectedRequest) {
@@ -192,7 +184,7 @@ public final class DefaultRequestMatcher implements RequestMatcher {
                     }
 
                 } else {
-                    if (expectedHeaderValue.matches((String) value)) {
+                    if (expectedHeaderValue.matches(value)) {
                         matched = true;
                         break;
                     }
@@ -224,7 +216,7 @@ public final class DefaultRequestMatcher implements RequestMatcher {
             }
 
             if (!expectedRequest.getBodyContentType().matches(actualContentType)) {
-                LOGGER.info("({} {}) REJECTED on content type: expected {}, actual {}", realRequest.getMethod(), realRequest.getPath(), expectedRequest.getBodyContentType(), (String) actualContentType);
+                LOGGER.info("({} {}) REJECTED on content type: expected {}, actual {}", realRequest.getMethod(), realRequest.getPath(), expectedRequest.getBodyContentType(), actualContentType);
                 return false;
             }
         }

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/jetty/DefaultClientDriverJettyHandler.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/jetty/DefaultClientDriverJettyHandler.java
@@ -158,8 +158,18 @@ public final class DefaultClientDriverJettyHandler extends AbstractHandler imple
             expectations.remove(index);
         }
         
+        captureBodyIfRequired(realRequest, matchedExpectation);
+
         return matchedExpectation.getPair();
     }
+
+	private void captureBodyIfRequired(HttpRealRequest realRequest,
+			ClientDriverExpectation matchedExpectation) {
+		ClientDriverRequest request = matchedExpectation.getPair().getRequest();
+		if (request.getBodyCapture() != null) {
+			request.getBodyCapture().setBody(realRequest.getBodyContent());
+		}
+	}
     
     @Override
     public void checkForUnexpectedRequests() {


### PR DESCRIPTION
This is to solve the situation when the capture body is populated and verified, then the driver.verify() is called. This can happen so fast that the expectation hasn't been removed and results in an unmatched exception.
