### PR TITLE
Let Jetty self find a free port

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriver.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriver.java
@@ -49,11 +49,11 @@ public final class ClientDriver {
      *            The {@link ClientDriverJettyHandler} to use.
      */
     public ClientDriver(ClientDriverJettyHandler handler) {
-        this(handler, getFreePort());
+        this(handler, 0);
     }
     
     /**
-     * Constructor. This will find a free port, bind to it and start the server
+     * Constructor. This will bind to the given port and start the server
      * up before it returns.
      * 
      * @param handler
@@ -64,12 +64,12 @@ public final class ClientDriver {
      */
     public ClientDriver(ClientDriverJettyHandler handler, int port) {
         
-        this.port = port;
         this.handler = handler;
-        
         jettyServer = new Server(port);
         
         startJetty();
+
+        this.port = jettyServer.getConnectors()[0].getLocalPort();
     }
     
     private void startJetty() {


### PR DESCRIPTION
This closes the window of opportunity for another process to grab the
port that ClientDriver have chosen before Jetty binds to it.

It closes #153.
