### PR TITLE
Binding all the interfaces in localhost while starting jetty

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriver.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriver.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.Connector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +77,9 @@ public final class ClientDriver {
         
         try {
             jettyServer.setHandler(handler);
+            for (Connector connector : jettyServer.getConnectors()) {
+                connector.setHost("0.0.0.0");
+            }
             jettyServer.start();
             
         } catch (Exception e) {


### PR DESCRIPTION
Rest driver was not working locally when my laptop had multiples interfaces with different IPs.
