### PR TITLE
Let Jetty find a free port by itself

### DIFF
--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ChooseOwnPortTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ChooseOwnPortTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
 import java.io.IOException;
-import java.net.BindException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
@@ -57,22 +56,22 @@ public class ChooseOwnPortTest {
         
     }
     
-    @Test
+    @Test(expected = ClientDriverSetupException.class)
     public void correctExceptionIsThrownIfPortIsUnavailable() throws IOException {
         
         int portNum = ClientDriver.getFreePort();
-        
-        try {
-            // one of these must throw an exception.
-            new ClientDriverFactory().createClientDriver(portNum);
-            new ClientDriverFactory().createClientDriver(portNum);
-            
-        } catch (ClientDriverSetupException cdse) {
-            
-            assertThat(cdse.getCause(), instanceOf(BindException.class));
-            
-        }
+
+        // one of these must throw an exception.
+        new ClientDriverFactory().createClientDriver(portNum);
+        new ClientDriverFactory().createClientDriver(portNum);
         
     }
-    
+
+    @Test
+    public void jettyFindsFreePortItself() {
+
+        new ClientDriverFactory().createClientDriver();
+        new ClientDriverFactory().createClientDriver();
+
+    }
 }


### PR DESCRIPTION
Send in 0 as the port when user has not specified a port. This makes
Jetty choose a random port.

To make sure the port Jetty has chosen is not taken, catch any eventual
BindExceptions and retry 2 times.

This closes #153.
