### PR TITLE
Reset expectations so ClientDriver can be reused

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriver.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriver.java
@@ -147,7 +147,11 @@ public final class ClientDriver {
         shutdownQuietly();
         verify();
     }
-    
+
+    public void reset() {
+        handler.reset();
+    }
+
     /**
      * Add in an expected {@link ClientDriverRequest}/{@link ClientDriverResponse} pair.
      * 

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/jetty/ClientDriverJettyHandler.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/jetty/ClientDriverJettyHandler.java
@@ -46,5 +46,9 @@ public interface ClientDriverJettyHandler extends Handler {
      * This method will throw a ClientDriverFailedExpectationException if any expectations have not been met.
      */
     void checkForUnmatchedExpectations();
-    
+
+    /**
+     * Resets the expectations so the current ClientDriver instance can be reused.
+     */
+    void reset();
 }

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/jetty/DefaultClientDriverJettyHandler.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/jetty/DefaultClientDriverJettyHandler.java
@@ -226,7 +226,14 @@ public final class DefaultClientDriverJettyHandler extends AbstractHandler imple
         }
         
     }
-    
+
+    @Override
+    public void reset() {
+        expectations.clear();
+        matchedResponses.clear();
+        unexpectedRequests.clear();
+    }
+
     private void waitFor(long time) {
         try {
             Thread.sleep(time);


### PR DESCRIPTION
When having many tests it would be nice to reuse a ClientDriver instance together with its Jetty server. This change enables that.
