### PR TITLE
Match header names, not just values

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/DefaultRequestMatcher.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/DefaultRequestMatcher.java
@@ -172,21 +172,23 @@ public final class DefaultRequestMatcher implements RequestMatcher {
             boolean matched = false;
             
             for (Entry<String, Object> actualHeader : actualHeaders.entrySet()) {
-                Object value = actualHeader.getValue();
-                if (value instanceof Enumeration) {
-                    Enumeration<String> valueEnumeration = (Enumeration<String>) value;
-                    while (valueEnumeration.hasMoreElements()) {
-                        String currentValue = valueEnumeration.nextElement();
-                        if (expectedHeaderValue.matches(currentValue)) {
+                if (actualHeader.getKey().equals(expectedHeaderName)) {
+                    Object value = actualHeader.getValue();
+                    if (value instanceof Enumeration) {
+                        Enumeration<String> valueEnumeration = (Enumeration<String>) value;
+                        while (valueEnumeration.hasMoreElements()) {
+                            String currentValue = valueEnumeration.nextElement();
+                            if (expectedHeaderValue.matches(currentValue)) {
+                                matched = true;
+                                break;
+                            }
+                        }
+                        
+                    } else {
+                        if (expectedHeaderValue.matches(value)) {
                             matched = true;
                             break;
                         }
-                    }
-                    
-                } else {
-                    if (expectedHeaderValue.matches(value)) {
-                        matched = true;
-                        break;
                     }
                 }
             }

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/unit/DefaultRequestMatcherTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/unit/DefaultRequestMatcherTest.java
@@ -463,6 +463,8 @@ public class DefaultRequestMatcherTest {
     @Test
     public void testMatchWrongWithMissingRequestHeaderString() throws Exception {
         
+        headers.put("Another-Header", "no-cache");
+        
         RealRequest real = mockRealRequest("aaaaa", Method.GET, headers, params, content, contentType);
         ClientDriverRequest expected = new ClientDriverRequest("aaaaa").withMethod(Method.GET).withHeader("Cache-Control", "no-cache");
         


### PR DESCRIPTION
This change ensures that to satisfy header expectations the incoming request must have a matching header name and value, not just value. The fix resolves a bug in which the following expectation:

```
.withHeader("a", "value")
```

Could be satisfied by supplying a header value:

```
b: value
```

(`git show -w` may make the exact change more apparent, or [w=1](https://github.com/joelittlejohn/rest-driver/commit/6d04def2b1976e2505fc7e334f012bae00a0da9a?w=1))
