### PR TITLE
Check headers case-insensitively.

### DIFF
--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverRequest.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/ClientDriverRequest.java
@@ -371,7 +371,7 @@ public final class ClientDriverRequest {
         if (CONTENT_TYPE.equalsIgnoreCase(withHeaderName)) {
             bodyContentType = headerValueMatcher;
         } else {
-            headers.put(withHeaderName, headerValueMatcher);
+            headers.put(withHeaderName.toLowerCase(), headerValueMatcher);
         }
         return this;
     }

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/DefaultRequestMatcher.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/DefaultRequestMatcher.java
@@ -151,7 +151,7 @@ public final class DefaultRequestMatcher implements RequestMatcher {
         Map<String, Object> actualHeaders = realRequest.getHeaders();
         
         for (String excludedHeader : excludedHeaders) {
-            if (actualHeaders.containsKey(excludedHeader)) {
+            if (actualHeaders.containsKey(excludedHeader.toLowerCase())) {
                 return true;
             }
         }
@@ -172,7 +172,7 @@ public final class DefaultRequestMatcher implements RequestMatcher {
             boolean matched = false;
             
             for (Entry<String, Object> actualHeader : actualHeaders.entrySet()) {
-                if (actualHeader.getKey().equals(expectedHeaderName)) {
+                if (actualHeader.getKey().equalsIgnoreCase(expectedHeaderName)) {
                     Object value = actualHeader.getValue();
                     if (value instanceof Enumeration) {
                         Enumeration<String> valueEnumeration = (Enumeration<String>) value;

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/HttpRealRequest.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/HttpRealRequest.java
@@ -64,7 +64,7 @@ public class HttpRealRequest implements RealRequest {
         if (headerNames != null) {
             while (headerNames.hasMoreElements()) {
                 String headerName = headerNames.nextElement();
-                headers.put(headerName, request.getHeader(headerName));
+                headers.put(headerName.toLowerCase(), request.getHeader(headerName));
             }
         }
         

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/unit/DefaultRequestMatcherTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/unit/DefaultRequestMatcherTest.java
@@ -502,6 +502,27 @@ public class DefaultRequestMatcherTest {
         assertThat(sut.isMatch(real, expected), is(false));
     }
     
+
+    @Test
+    public void testExpectedHeadersAreCheckedCaseInsensitively() throws Exception {
+
+        headers.put("host", "testhost");
+        RealRequest real = mockRealRequest("aaaaa", Method.GET, headers, params, content, contentType);
+        ClientDriverRequest expected = new ClientDriverRequest("aaaaa").withMethod(Method.GET).withHeader("Host", Pattern.compile("testhost"));
+
+        assertThat(sut.isMatch(real, expected), is(true));
+    }
+
+    @Test
+    public void testExcludedHeadersAreCheckedCaseInsensitively() throws Exception {
+
+        headers.put("host", "testhost");
+        RealRequest real = mockRealRequest("aaaaa", Method.GET, headers, params, content, contentType);
+        ClientDriverRequest expected = new ClientDriverRequest("aaaaa").withMethod(Method.GET).withoutHeader("Host");
+
+        assertThat(sut.isMatch(real, expected), is(false));
+    }
+    
     private static List<String> asStringList(String... strings) {
         return Arrays.asList(strings);
     }


### PR DESCRIPTION
Here's a patch to make sure headers names are checked case-insensitively.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
"Field names are case-insensitive."
