### PR TITLE
Update Jetty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
         <hamcrest.version>1.3</hamcrest.version>
         <httpclient.version>4.5.1</httpclient.version>
         <jackson.version>2.2.0</jackson.version>
-        <jetty.version>9.1.1.v20140108</jetty.version>
+        <jetty.version>9.3.7.v20160115</jetty.version>
         <joda.time.version>2.2</joda.time.version>
         <junit.version>4.11</junit.version>
         <jsonpath.version>0.8.1</jsonpath.version>
-        <logback.version>1.0.12</logback.version>
+        <logback.version>1.1.1</logback.version>
         <mockito.version>1.9.5</mockito.version>
         <slf4j.version>1.7.5</slf4j.version>
         <xmlunit.version>1.4</xmlunit.version>

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/HttpRealRequest.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/HttpRealRequest.java
@@ -50,7 +50,7 @@ public class HttpRealRequest implements RealRequest {
         
         if (request.getQueryString() != null) {
             MultiMap<String> parameterMap = new MultiMap<String>();
-            UrlEncoded.decodeTo(request.getQueryString(), parameterMap, "UTF-8", 0);
+            UrlEncoded.decodeTo(request.getQueryString(), parameterMap, "UTF-8");
             for (Entry<String, String[]> paramEntry : parameterMap.toStringArrayMap().entrySet()) {
                 String[] values = paramEntry.getValue();
                 for (String value : values) {

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
@@ -361,10 +361,10 @@ public class ClientDriverSuccessTest {
         
         String baseUrl = driver.getBaseUrl();
         driver.addExpectation(
-                onRequestTo("/without-header-test").withMethod(Method.GET).withoutHeader("Some Header"),
+                onRequestTo("/without-header-test").withMethod(Method.GET).withoutHeader("SomeHeader"),
                 giveEmptyResponse().withStatus(204).withHeader("Cache-Control", "no-cache"));
         driver.addExpectation(
-                onRequestTo("/without-header-test").withMethod(Method.GET).withHeader("Some Header", "hello"),
+                onRequestTo("/without-header-test").withMethod(Method.GET).withHeader("SomeHeader", "hello"),
                 giveEmptyResponse().withStatus(418).withHeader("Cache-Control", "no-cache"));
         
         HttpClient client = new DefaultHttpClient();
@@ -374,7 +374,7 @@ public class ClientDriverSuccessTest {
         assertThat(response.getStatusLine().getStatusCode(), is(204));
         
         get = new HttpGet(baseUrl + "/without-header-test");
-        get.addHeader(new BasicHeader("Some Header", "hello"));
+        get.addHeader(new BasicHeader("SomeHeader", "hello"));
         response = client.execute(get);
         
         assertThat(response.getStatusLine().getStatusCode(), is(418));


### PR DESCRIPTION
The method signature for `UrlEncoded#decodeTo` has changed, which prevents apps using `rest-client-driver` from using a recent version of Jetty. This change updates Jetty and fixes the incompatibility.