### PR TITLE
RFC: Upgrade to jetty 9.3.8.v20160314 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <httpclient.version>4.5.1</httpclient.version>
         <jackson.version>2.2.0</jackson.version>
-        <jetty.version>9.1.1.v20140108</jetty.version>
+        <jetty.version>9.3.8.v20160314</jetty.version>
         <joda.time.version>2.2</joda.time.version>
         <junit.version>4.11</junit.version>
         <jsonpath.version>0.8.1</jsonpath.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <joda.time.version>2.2</joda.time.version>
         <junit.version>4.11</junit.version>
         <jsonpath.version>0.8.1</jsonpath.version>
-        <logback.version>1.0.12</logback.version>
+        <logback.version>1.1.7</logback.version>
         <mockito.version>1.9.5</mockito.version>
         <slf4j.version>1.7.5</slf4j.version>
         <xmlunit.version>1.4</xmlunit.version>

--- a/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/HttpRealRequest.java
+++ b/rest-client-driver/src/main/java/com/github/restdriver/clientdriver/HttpRealRequest.java
@@ -16,6 +16,7 @@
 package com.github.restdriver.clientdriver;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -34,6 +35,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class HttpRealRequest implements RealRequest {
     
     private final Method method;
@@ -50,7 +53,7 @@ public class HttpRealRequest implements RealRequest {
         
         if (request.getQueryString() != null) {
             MultiMap<String> parameterMap = new MultiMap<String>();
-            UrlEncoded.decodeTo(request.getQueryString(), parameterMap, "UTF-8", 0);
+            UrlEncoded.decodeTo(request.getQueryString(), parameterMap, UTF_8);
             for (Entry<String, String[]> paramEntry : parameterMap.toStringArrayMap().entrySet()) {
                 String[] values = paramEntry.getValue();
                 for (String value : values) {

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
@@ -44,6 +44,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -357,6 +358,7 @@ public class ClientDriverSuccessTest {
     }
     
     @Test
+    @Ignore
     public void matchingOnRequestHeaderNotBeingPresent() throws Exception {
         
         String baseUrl = driver.getBaseUrl();

--- a/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
+++ b/rest-client-driver/src/test/java/com/github/restdriver/clientdriver/integration/ClientDriverSuccessTest.java
@@ -44,7 +44,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -358,15 +357,14 @@ public class ClientDriverSuccessTest {
     }
     
     @Test
-    @Ignore
     public void matchingOnRequestHeaderNotBeingPresent() throws Exception {
         
         String baseUrl = driver.getBaseUrl();
         driver.addExpectation(
-                onRequestTo("/without-header-test").withMethod(Method.GET).withoutHeader("Some Header"),
+                onRequestTo("/without-header-test").withMethod(Method.GET).withoutHeader("Some-Header"),
                 giveEmptyResponse().withStatus(204).withHeader("Cache-Control", "no-cache"));
         driver.addExpectation(
-                onRequestTo("/without-header-test").withMethod(Method.GET).withHeader("Some Header", "hello"),
+                onRequestTo("/without-header-test").withMethod(Method.GET).withHeader("Some-Header", "hello"),
                 giveEmptyResponse().withStatus(418).withHeader("Cache-Control", "no-cache"));
         
         HttpClient client = new DefaultHttpClient();
@@ -376,7 +374,7 @@ public class ClientDriverSuccessTest {
         assertThat(response.getStatusLine().getStatusCode(), is(204));
         
         get = new HttpGet(baseUrl + "/without-header-test");
-        get.addHeader(new BasicHeader("Some Header", "hello"));
+        get.addHeader(new BasicHeader("Some-Header", "hello"));
         response = client.execute(get);
         
         assertThat(response.getStatusLine().getStatusCode(), is(418));

--- a/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/ProxyAcceptanceTest.java
+++ b/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/ProxyAcceptanceTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.proxy.ProxyServlet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -39,6 +40,7 @@ import com.github.restdriver.clientdriver.ClientDriverResponse;
 import com.github.restdriver.clientdriver.ClientDriverRule;
 import com.github.restdriver.serverdriver.http.exception.RuntimeConnectException;
 
+@Ignore
 public class ProxyAcceptanceTest {
     
     /* These are set when you call startLocalProxy() */

--- a/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/ProxyAcceptanceTest.java
+++ b/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/ProxyAcceptanceTest.java
@@ -40,7 +40,6 @@ import com.github.restdriver.clientdriver.ClientDriverResponse;
 import com.github.restdriver.clientdriver.ClientDriverRule;
 import com.github.restdriver.serverdriver.http.exception.RuntimeConnectException;
 
-@Ignore
 public class ProxyAcceptanceTest {
     
     /* These are set when you call startLocalProxy() */

--- a/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/ProxyAcceptanceTest.java
+++ b/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/ProxyAcceptanceTest.java
@@ -29,7 +29,6 @@ import org.eclipse.jetty.proxy.ProxyServlet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;


### PR DESCRIPTION
This is an RFC for upgrading to Jetty 9.3.8. I need this to run rest-driver in the same classpath as Solr 6.0.0, ref #178 

I had to ignore a couple of tests to make it build, and quite haven't figured out why they fail yet.

All help with this would be great!