### PR TITLE
remove joda time as dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <httpclient.version>4.5.13</httpclient.version>
         <jackson.version>2.12.1</jackson.version>
         <jetty.version>9.4.35.v20201120</jetty.version>
-        <joda.time.version>2.10.9</joda.time.version>
         <junit.version>4.13.1</junit.version>
         <jsonpath.version>0.9.1</jsonpath.version>
         <logback.version>1.1.7</logback.version>
@@ -246,12 +245,6 @@
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${commons.lang.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${joda.time.version}</version>
             </dependency>
 
             <dependency>

--- a/rest-server-driver/pom.xml
+++ b/rest-server-driver/pom.xml
@@ -66,11 +66,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/http/Header.java
+++ b/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/http/Header.java
@@ -18,9 +18,9 @@ package com.github.restdriver.serverdriver.http;
 import javax.annotation.Generated;
 
 import org.apache.commons.lang.StringUtils;
-import org.joda.time.DateTime;
 
 import com.github.restdriver.serverdriver.matchers.Rfc1123DateMatcher;
+import java.time.ZonedDateTime;
 
 /**
  * Represents an HTTP header.
@@ -93,7 +93,7 @@ public final class Header implements AnyRequestModifier {
      * 
      * @return The DateTime object..
      */
-    public DateTime asDateTime() {
+    public ZonedDateTime asDateTime() {
         return new Rfc1123DateMatcher().getDateTime(this.getValue());
     }
     

--- a/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/http/exception/RuntimeDateFormatException.java
+++ b/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/http/exception/RuntimeDateFormatException.java
@@ -15,24 +15,25 @@
  */
 package com.github.restdriver.serverdriver.http.exception;
 
-import java.text.ParseException;
+import java.time.format.DateTimeParseException;
 
 /**
- * Runtime wrapper for {@link java.text.ParseException}. caused by badly-formatted dates.
- * 
+ * Runtime wrapper for {@link java.text.ParseException}. caused by
+ * badly-formatted dates.
+ *
  * User: mjg Date: 14/05/11 Time: 21:52
  */
 public class RuntimeDateFormatException extends RuntimeException {
-    
+
     private static final long serialVersionUID = 2177515119789644219L;
-    
+
     /**
      * Constructor which takes the original ParseException.
-     * 
+     *
      * @param pe The original ParseException.
      */
-    public RuntimeDateFormatException(ParseException pe) {
+    public RuntimeDateFormatException(DateTimeParseException pe) {
         super(pe);
     }
-    
+
 }

--- a/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/matchers/Rfc1123DateMatcher.java
+++ b/rest-server-driver/src/main/java/com/github/restdriver/serverdriver/matchers/Rfc1123DateMatcher.java
@@ -15,17 +15,15 @@
  */
 package com.github.restdriver.serverdriver.matchers;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
 
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import com.github.restdriver.serverdriver.http.Header;
 import com.github.restdriver.serverdriver.http.exception.RuntimeDateFormatException;
+import java.time.ZonedDateTime;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import java.time.format.DateTimeParseException;
 
 /**
  * Matcher to check that headers contain dates which are spec-valid. All dates in HTTP headers (Date-header, caching, etc) should
@@ -33,25 +31,18 @@ import com.github.restdriver.serverdriver.http.exception.RuntimeDateFormatExcept
  */
 public final class Rfc1123DateMatcher extends TypeSafeMatcher<Header> {
     
-    public static final String DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
-    
     /**
      * Parse a string as if it is an RFC1123-compliant date.
      * 
      * @param rawString The original String.
      * @return The DateTime object set to UTC.
      */
-    public DateTime getDateTime(String rawString) {
-        SimpleDateFormat formatter = new SimpleDateFormat(DATE_FORMAT, Locale.US);
-        formatter.setLenient(false); // This stops well-formatted but invalid dates like Feb 31
-        
+    public ZonedDateTime getDateTime(String rawString) {
         try {
-            return new DateTime(formatter.parse(rawString)).toDateTime(DateTimeZone.UTC);
-            
-        } catch (ParseException pe) {
+            return ZonedDateTime.parse(rawString, RFC_1123_DATE_TIME);
+        } catch (DateTimeParseException pe) {
             throw new RuntimeDateFormatException(pe);
         }
-        
     }
     
     @Override

--- a/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/Rfc1123DatesInHeadersAcceptanceTest.java
+++ b/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/acceptance/Rfc1123DatesInHeadersAcceptanceTest.java
@@ -20,8 +20,6 @@ import static com.github.restdriver.serverdriver.RestServerDriver.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeConstants;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -29,69 +27,72 @@ import com.github.restdriver.clientdriver.ClientDriverRequest;
 import com.github.restdriver.clientdriver.ClientDriverResponse;
 import com.github.restdriver.clientdriver.ClientDriverRule;
 import com.github.restdriver.serverdriver.http.response.Response;
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.time.ZonedDateTime;
 
 public class Rfc1123DatesInHeadersAcceptanceTest {
-    
+
     private final String compliantDate = "Mon, 09 May 2011 18:49:18 GMT";
     private final String unCompliantDate = "Junk, 09 May 2011 18:49:18 GMT";
     private final String compliantButInvalidDate = "Mon, 12 May 2011 18:49:18 GMT"; // was not a Monday
-    
+
     @Rule
     public ClientDriverRule driver = new ClientDriverRule();
-    
+
     @Test
     public void assertOnValidDateHeader() {
-        
+
         driver.addExpectation(new ClientDriverRequest("/"), new ClientDriverResponse().withHeader("Date", compliantDate));
         Response response = get(driver.getBaseUrl());
-        
+
         assertThat(response.getHeader("Date"), isValidDateHeader());
         assertThat(response.getHeader("Date"), isRfc1123Compliant());
-        
+
     }
-    
+
     @Test
     public void assertOnInvalidFormatDateHeader() {
-        
+
         driver.addExpectation(new ClientDriverRequest("/"), new ClientDriverResponse().withHeader("Date", unCompliantDate));
         Response response = get(driver.getBaseUrl());
-        
+
         assertThat(response.getHeader("Date"), not(isValidDateHeader()));
         assertThat(response.getHeader("Date"), not(isRfc1123Compliant()));
-        
+
     }
-    
+
     @Test
     public void assertOnInvalidDateHeader() {
-        
+
         driver.addExpectation(new ClientDriverRequest("/"), new ClientDriverResponse().withHeader("Date", compliantButInvalidDate));
         Response response = get(driver.getBaseUrl());
-        
+
         assertThat(response.getHeader("Date"), not(isValidDateHeader()));
         assertThat(response.getHeader("Date"), not(isRfc1123Compliant()));
-        
+
     }
-    
+
     @Test
     public void getHeaderAsDateTimeProvidesCorrectDate() {
-        
+
         String testDate = "Mon, 09 May 2011 18:49:18 GMT";
-        
+
         driver.addExpectation(new ClientDriverRequest("/"), new ClientDriverResponse().withHeader("Date", testDate));
         Response response = get(driver.getBaseUrl());
-        
-        DateTime headerDate = response.getHeader("Date").asDateTime();
-        
-        assertThat(headerDate.getDayOfWeek(), is(DateTimeConstants.MONDAY));
-        
+
+        ZonedDateTime headerDate = response.getHeader("Date").asDateTime();
+
+        assertThat(headerDate.getDayOfWeek(), is(DayOfWeek.MONDAY));
+
         assertThat(headerDate.getDayOfMonth(), is(9));
-        assertThat(headerDate.getMonthOfYear(), is(DateTimeConstants.MAY));
+        assertThat(headerDate.getMonth(), is(Month.MAY));
         assertThat(headerDate.getYear(), is(2011));
-        
-        assertThat(headerDate.getHourOfDay(), is(18));
-        assertThat(headerDate.getMinuteOfHour(), is(49));
-        assertThat(headerDate.getSecondOfMinute(), is(18));
-        
+
+        assertThat(headerDate.getHour(), is(18));
+        assertThat(headerDate.getMinute(), is(49));
+        assertThat(headerDate.getSecond(), is(18));
+
     }
-    
+
 }

--- a/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/http/HeaderTest.java
+++ b/rest-server-driver/src/test/java/com/github/restdriver/serverdriver/http/HeaderTest.java
@@ -20,99 +20,100 @@ import static org.hamcrest.Matchers.*;
 
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeConstants;
 import org.junit.Test;
 
 import com.github.restdriver.serverdriver.http.exception.RuntimeDateFormatException;
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.time.ZonedDateTime;
 
 public class HeaderTest {
-    
+
     @Test
     public void newlyCreatedHeaderHasCorrectName() {
         Header header = new Header("name", "value");
         assertThat(header.getName(), is("name"));
     }
-    
+
     @Test
     public void newlyCreatedHeaderHasCorrectValue() {
         Header header = new Header("name", "value");
         assertThat(header.getValue(), is("value"));
     }
-    
+
     @Test
     public void headerHasSensibleToString() {
         Header header = new Header("name", "value");
         assertThat(header.toString(), is("name: value"));
     }
-    
+
     @Test
     public void headerHashCodeIsTheSameForEqualHeaders() {
         Header header1 = new Header("name", "value");
         Header header2 = new Header("name", "value");
         assertThat(header1.hashCode(), equalTo(header2.hashCode()));
     }
-    
+
     @Test
     public void headerHashCodeIsDifferentForDifferentName() {
         Header header1 = new Header("name", "value");
         Header header2 = new Header("different", "value");
         assertThat(header1.hashCode(), not(equalTo(header2.hashCode())));
     }
-    
+
     @Test
     public void headerHashCodeIsDifferentForDifferentValue() {
         Header header1 = new Header("name", "value");
         Header header2 = new Header("name", "different");
         assertThat(header1.hashCode(), not(equalTo(header2.hashCode())));
     }
-    
+
     @Test
     public void headerIsEqualToItself() {
         Header header = new Header("name", "value");
         assertThat(header, equalTo(header));
     }
-    
+
     @Test
     public void headerIsNotEqualToObjectOfAnotherType() {
         Header header = new Header("name", "value");
         assertThat(header.equals(""), is(false));
     }
-    
+
     @Test
     public void headersAreEqualWithSameNameAndValue() {
         Header header1 = new Header("name", "value");
         Header header2 = new Header("name", "value");
         assertThat(header1, equalTo(header2));
     }
-    
+
     @Test
     public void headersAreNotEqualWithDifferentName() {
         Header header1 = new Header("name", "value");
         Header header2 = new Header("different", "value");
         assertThat(header1, not(equalTo(header2)));
     }
-    
+
     @Test
     public void headersAreNotEqualWithDifferentValue() {
         Header header1 = new Header("name", "value");
         Header header2 = new Header("name", "different");
         assertThat(header1, not(equalTo(header2)));
     }
-    
+
     @Test
     public void headerWithNullNameAndValueHasHashCode() {
         Header header = new Header(null, null);
         assertThat(header.hashCode() > 0, is(true));
     }
-    
+
     @Test
     public void headerWithSingleStringIsParsedCorrectly() {
         Header header = new Header("X-foo: blah");
         assertThat(header.getName(), is("X-foo"));
         assertThat(header.getValue(), is("blah"));
     }
-    
+
     @Test
     public void headerWithSingleStringAndCrazyWhitespaceIsParsedCorrectly() {
         // NB this is not valid according to HTTP spec, but we allow it anyway.
@@ -120,68 +121,68 @@ public class HeaderTest {
         assertThat(header.getName(), is("X-foo"));
         assertThat(header.getValue(), is("blah"));
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void headerWithSingleStringAndNoColonIsIllegal() {
         new Header("  X-foo ");
     }
-    
+
     @Test
     public void headerWithSingleStringAndTwoColonsIsLegal() {
         Header header = new Header("  X-foo : yes : perhaps");
-        
+
         assertThat(header.getName(), is("X-foo"));
         assertThat(header.getValue(), is("yes : perhaps"));
     }
-    
+
     public void headerAppliesItselfToRequest() {
         HttpUriRequest request = new HttpGet();
         Header header = new Header("name", "value");
         header.applyTo(new ServerDriverHttpUriRequest(request));
         assertThat(request.getFirstHeader("name").getValue(), is("value"));
     }
-    
+
     @Test
     public void headerNameIsCaseInsensitiveButValueIsnt() {
         Header upper = new Header("HELLO: there");
         Header lower = new Header("hello: there");
         Header lowerUpper = new Header("hello: THERE");
-        
+
         assertThat(upper, equalTo(lower));
         assertThat(lower, not(equalTo(lowerUpper)));
     }
-    
+
     @Test
     public void hashCodeTreatsNameAsCaseInsensitive() {
         Header upper = new Header("HELLO: there");
         Header lower = new Header("hello: there");
-        
+
         assertThat(upper.hashCode(), equalTo(lower.hashCode()));
     }
-    
+
     @Test
     public void asDateTimeReturnsCorrectDate() {
         Header dateHeader = new Header("HELLO: Mon, 09 May 2011 18:49:18 GMT");
-        
-        DateTime headerDate = dateHeader.asDateTime();
-        
-        assertThat(headerDate.getDayOfWeek(), is(DateTimeConstants.MONDAY));
-        
+
+        ZonedDateTime headerDate = dateHeader.asDateTime();
+
+        assertThat(headerDate.getDayOfWeek(), is(DayOfWeek.MONDAY));
+
         assertThat(headerDate.getDayOfMonth(), is(9));
-        assertThat(headerDate.getMonthOfYear(), is(DateTimeConstants.MAY));
+        assertThat(headerDate.getMonth(), is(Month.MAY));
         assertThat(headerDate.getYear(), is(2011));
-        
-        assertThat(headerDate.getHourOfDay(), is(18));
-        assertThat(headerDate.getMinuteOfHour(), is(49));
-        assertThat(headerDate.getSecondOfMinute(), is(18));
-        
+
+        assertThat(headerDate.getHour(), is(18));
+        assertThat(headerDate.getMinute(), is(49));
+        assertThat(headerDate.getSecond(), is(18));
+
     }
-    
+
     @Test(expected = RuntimeDateFormatException.class)
     public void asDateTimeThrowsIfNotCorrectFormat() {
         Header dateHeader = new Header("HELLO: XXX, 09 May 2011 18:49:18 GMT");
-        
+
         dateHeader.asDateTime();
     }
-    
+
 }


### PR DESCRIPTION
Fixes #205.

The Header.asDateTime() method is public API. 
As 2.0.0 already released, this would require 3.0.0. Let's talk about this ;-)